### PR TITLE
Refactoring to replace comments with methods

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -7,7 +7,7 @@
 
 import { injectable, inject } from "inversify";
 import URI from '@theia/core/lib/common/uri';
-import { ICompositeTreeNode, TreeModel, TreeServices } from "@theia/core/lib/browser";
+import { ICompositeTreeNode, TreeModel, TreeServices, ITreeNode } from "@theia/core/lib/browser";
 import { FileSystem, FileSystemWatcher, FileChangeType, FileChange } from "../../common";
 import { FileStatNode, DirNode, FileTree } from "./file-tree";
 import { LocationService } from '../location';
@@ -88,8 +88,7 @@ export class FileTreeModel extends TreeModel implements LocationService {
     protected getAffectedNodes(changes: FileChange[]): ICompositeTreeNode[] {
         const nodes: DirNode[] = [];
         for (const change of changes) {
-            const uri = change.uri;
-            const id = change.type > FileChangeType.UPDATED ? uri.parent.toString() : uri.toString();
+            const id = change.uri.parent.toString();
             const node = this.getNode(id);
             if (DirNode.is(node) && node.expanded) {
                 nodes.push(node);
@@ -111,23 +110,21 @@ export class FileTreeModel extends TreeModel implements LocationService {
         return true;
     }
 
+    /**
+     * Move the given source file or directory to the given target directory.
+     */
+    async move(source: ITreeNode, target: ITreeNode) {
+        if (DirNode.is(target) && FileStatNode.is(source)) {
+            const sourceUri = source.uri.toString();
+            const targetUri = target.uri.resolve(source.name).toString();
+            await this.fileSystem.move(sourceUri, targetUri, { overwrite: true });
+        }
+    }
+
     upload(node: DirNode, items: DataTransferItemList): void {
         for (let i = 0; i < items.length; i++) {
-            if (items[i].kind === 'file') {
-                // File from outside Theia
-                const entry = items[i].webkitGetAsEntry() as WebKitEntry;
-                this.uploadEntry(node.uri, entry);
-            } else if (items[i].kind === 'string' && items[i].type === "theia-nodeid") {
-                // Files/folders to move from inside theia
-                items[i].getAsString(id => {
-                    const nodeToMove = this.tree.getNode(id);
-                    if (nodeToMove !== undefined) {
-                        const newBase = node.uri.resolve(nodeToMove.name);
-                        const destination = newBase.toString();
-                        this.move(id, destination);
-                    }
-                });
-            }
+            const entry = items[i].webkitGetAsEntry() as WebKitEntry;
+            this.uploadEntry(node.uri, entry);
         }
     }
 
@@ -180,7 +177,4 @@ export class FileTreeModel extends TreeModel implements LocationService {
         }
     }
 
-    protected move(uriToMove: string, nodeDest: string) {
-        this.fileSystem.move(uriToMove, nodeDest, { overwrite: true }).then(e => this.refresh());
-    }
 }


### PR DESCRIPTION
@lmcbout I've refactored a PR to:
- get rid of comments and replace them with semantically meaningful methods: https://refactoring.guru/smells/comments
- get rid of calling `refresh` after the move by fixing computation of affected file tree nodes on filesystem changes, we use unidirectional flow pattern, where the tree widget is completely redrawn on change of filesystem, explicit calls of `refresh` is discouraged
- apply draggable only to file stat tree nodes and allow to move only to a dir node

Please review and merge.

Could you work next time in Theia repo, not in your fork, please? It is hard to open PRs against forks, GitHub does not support such case very well.